### PR TITLE
[FEAT] 로그인/회원가입 페이지 api 연동

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,11 @@
-import { Button, Text } from '@vapor-ui/core';
+import { Button, Text, Menu } from '@vapor-ui/core';
 import { ShoppingCartIcon, UserIcon } from '@vapor-ui/icons';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 
 const Header = () => {
   const navigate = useNavigate();
+  const { user, isAdmin, logout } = useAuth();
   return (
     <header className='flex justify-between items-center p-4 border-b border-gray-200 mb-6 bg-white shadow-sm'>
       <div className='cursor-pointer' onClick={() => navigate('/')}>
@@ -18,14 +20,53 @@ const Header = () => {
           <ShoppingCartIcon size={20} />{' '}
           <span className='hidden sm:inline'>장바구니</span>
         </Button>
-        <Button
-          variant='ghost'
-          onClick={() => navigate('/login')}
-          className='flex items-center gap-1'
-        >
-          <UserIcon size={20} />{' '}
-          <span className='hidden sm:inline'>로그인</span>
-        </Button>
+        {!user && (
+          <Button
+            variant='ghost'
+            onClick={() => navigate('/login')}
+            className='flex items-center gap-1'
+          >
+            <UserIcon size={20} />{' '}
+            <span className='hidden sm:inline'>로그인</span>
+          </Button>
+        )}
+        {user && !isAdmin && (
+          <Menu.Root>
+            <Menu.Trigger
+              render={
+                <Button variant='ghost' className='flex items-center gap-1'>
+                  <UserIcon size={20} />
+                  <span className='hidden sm:inline'>{user?.user_name}</span>
+                </Button>
+              }
+            />
+            <Menu.Popup>
+              <Menu.Item onClick={logout}>로그아웃</Menu.Item>
+            </Menu.Popup>
+          </Menu.Root>
+        )}
+        {user && isAdmin && (
+          <Menu.Root>
+            <Menu.Trigger
+              render={
+                <Button variant='ghost' className='flex items-center gap-1'>
+                  <UserIcon size={20} />
+                  <span className='hidden sm:inline'>{user?.user_name}</span>
+                </Button>
+              }
+            />
+            <Menu.Popup>
+              <Menu.Item onClick={() => navigate('/admin/products')}>
+                상품 관리
+              </Menu.Item>
+              <Menu.Item onClick={() => navigate('/admin/members')}>
+                회원 관리
+              </Menu.Item>
+              <Menu.Separator />
+              <Menu.Item onClick={logout}>로그아웃</Menu.Item>
+            </Menu.Popup>
+          </Menu.Root>
+        )}
       </div>
     </header>
   );

--- a/src/components/route/AdminRoute.tsx
+++ b/src/components/route/AdminRoute.tsx
@@ -1,6 +1,8 @@
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { useEffect } from 'react';
 import React from 'react';
+import { toastManager } from '../../lib/toastManager';
 
 /**
  * 어드민 권한을 필요로 하는 라우트
@@ -9,6 +11,15 @@ import React from 'react';
  */
 export function AdminRoute({ children }: { children: React.ReactNode }) {
   const { user, isLoading, isAdmin } = useAuth();
+
+  useEffect(() => {
+    if (!isLoading && user && !isAdmin) {
+      toastManager.add({
+        title: '접근 권한이 없습니다.',
+        colorPalette: 'danger',
+      });
+    }
+  }, [isLoading, user, isAdmin]);
 
   if (isLoading)
     return (

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,10 +1,25 @@
 import { renderHook, act } from '@testing-library/react';
 import { AuthProvider, useAuth } from './AuthContext';
 
+const mockLogin = vi.hoisted(() => vi.fn());
+const mockLogout = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/index', () => ({
+  authAPI: {
+    login: mockLogin,
+    logout: mockLogout,
+  },
+  userAPI: {
+    getMe: vi.fn(),
+  },
+}));
+
 describe('AuthContext', () => {
   // 매 테스트 이전에 로컬 스토리지 초기화
   beforeEach(() => {
     localStorage.clear();
+    mockLogin.mockClear();
+    mockLogout.mockClear();
   });
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -19,6 +34,17 @@ describe('AuthContext', () => {
   });
 
   it('login -> user 상태 및 localStorage 업데이트', async () => {
+    mockLogin.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 1,
+          user_email: 'user@goorm.io',
+          user_name: '테스트',
+          user_role: 'USER',
+          token: 'mockToken',
+        },
+      },
+    });
     const { result } = renderHook(() => useAuth(), { wrapper });
     await act(async () => {
       await result.current.login('user@goorm.io', 'password');
@@ -29,6 +55,17 @@ describe('AuthContext', () => {
   });
 
   it('admin 로그인 시 isAdmin = true', async () => {
+    mockLogin.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 1,
+          user_email: 'admin@goorm.io',
+          user_name: '관리자',
+          user_role: 'ADMIN',
+          token: 'mockToken',
+        },
+      },
+    });
     const { result } = renderHook(() => useAuth(), { wrapper });
     await act(async () => {
       await result.current.login('admin@goorm.io', 'password');
@@ -38,6 +75,17 @@ describe('AuthContext', () => {
   });
 
   it('user 로그인 시 isAdmin = false', async () => {
+    mockLogin.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 1,
+          user_email: 'user@goorm.io',
+          user_name: '테스트',
+          user_role: 'USER',
+          token: 'mockToken',
+        },
+      },
+    });
     const { result } = renderHook(() => useAuth(), { wrapper });
     await act(async () => {
       await result.current.login('user@goorm.io', 'password');
@@ -47,12 +95,24 @@ describe('AuthContext', () => {
   });
 
   it('logout 후 user null, localStorage 제거', async () => {
+    mockLogin.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 1,
+          user_email: 'admin@goorm.io',
+          user_name: '관리자',
+          user_role: 'ADMIN',
+          token: 'mockToken',
+        },
+      },
+    });
+    mockLogout.mockResolvedValueOnce({});
     const { result } = renderHook(() => useAuth(), { wrapper });
     await act(async () => {
       await result.current.login('admin@goorm.io', 'password');
     });
-    act(() => {
-      result.current.logout();
+    await act(async () => {
+      await result.current.logout();
     });
     expect(result.current.user).toBeNull();
     expect(localStorage.getItem('token')).toBeNull();

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import type { User } from '../types';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { ReactNode } from 'react';
+import { authAPI, userAPI } from '../api/index';
 
 /** Context 타입 */
 interface AuthContextType {
@@ -8,49 +9,78 @@ interface AuthContextType {
   isLoading: boolean;
   isAdmin: boolean;
   login: (user_email: string, user_password: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
-/** 인증 상태 Provider */
+/**
+ * 인증 상태를 관리하는 Context Provider
+ * - 로그인 상태 유지: 새로고침 시 localStorage에서 토큰과 유저 정보 확인
+ * - 로그인: API 호출 후 토큰과 유저 정보 저장
+ * - 로그아웃: API 호출 후 토큰과 유저 정보 제거
+ * - 인증 상태와 로그인/로그아웃 함수를 하위 컴포넌트에 제공
+ */
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   /** 새로고침 시 localStorage로부터 유저 복원 */
   useEffect(() => {
-    const stored = localStorage.getItem('user');
-    if (stored) {
-      setUser(JSON.parse(stored));
+    const token = localStorage.getItem('token');
+    if (!token) {
+      setIsLoading(false);
+      return;
     }
-    setIsLoading(false);
+
+    userAPI
+      .getMe()
+      .then((res) => {
+        const { id, email, name, role } = res.data.data;
+        const user: User = {
+          id,
+          user_email: email,
+          user_name: name,
+          user_role: role,
+        };
+        localStorage.setItem('user', JSON.stringify(user));
+        setUser(user);
+      })
+      .catch(() => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+        setUser(null);
+      })
+      .finally(() => setIsLoading(false));
   }, []);
 
-  /** 로그인
-   * @now 목업 데이터
-   * @todo 실제 api 호출
+  /**
+   * AuthAPI의 로그인 호출 후 토큰과 유저 정보 저장
+   * @param user_email
+   * @param user_password
    */
   const login = async (user_email: string, user_password: string) => {
-    const mockUser: User = {
-      id: 1,
-      user_email,
-      user_name: 'goorm',
-      user_role: user_email === 'admin@goorm.io' ? 'ADMIN' : 'USER',
-    };
+    const res = await authAPI.login({ user_email, user_password });
+    const { token, ...userData } = res.data.data;
 
-    localStorage.setItem('token', 'mockToken');
-    localStorage.setItem('user', JSON.stringify(mockUser));
-    setUser(mockUser);
+    localStorage.setItem('token', token);
+    localStorage.setItem('user', JSON.stringify(userData));
+    setUser(userData);
   };
 
-  /** 로그아웃 */
-  const logout = () => {
+  /**
+   * AuthAPI의 로그아웃 호출 후 토큰과 유저 정보 제거
+   */
+  const logout = async () => {
+    await authAPI.logout();
     localStorage.removeItem('token');
     localStorage.removeItem('user');
     setUser(null);
   };
 
+  /**
+   * AuthContext.Provider로 인증 상태와 로그인/로그아웃 함수를 하위 컴포넌트에 제공
+   */
   return (
     <AuthContext.Provider
       value={{

--- a/src/pages/admin/MembersManagePage.test.tsx
+++ b/src/pages/admin/MembersManagePage.test.tsx
@@ -17,6 +17,10 @@ vi.mock('../../lib/toastManager', () => ({
   toastManager: { add: vi.fn() },
 }));
 
+vi.mock('../../components/Header', () => ({
+  default: () => null,
+}));
+
 const mockMembers = [
   { id: 1, email: 'admin@test.com', name: '관리자', role: 'ADMIN' },
   { id: 2, email: 'user@test.com', name: '홍길동', role: 'USER' },

--- a/src/pages/admin/MembersManagePage.tsx
+++ b/src/pages/admin/MembersManagePage.tsx
@@ -29,6 +29,7 @@ import {
 import type { User } from '../../types';
 import { toastManager } from '../../lib/toastManager';
 import { adminMemberAPI } from '../../api/index';
+import Header from '../../components/Header';
 
 // 상수
 const ROLES = ['USER', 'ADMIN'] as const;
@@ -302,242 +303,249 @@ export default function MembersManagePage() {
   });
 
   return (
-    <div className='p-6 max-w-5xl mx-auto'>
-      <h1 className='text-2xl font-bold mb-6'>사용자 관리</h1>
+    <div className='min-h-screen bg-gray-50'>
+      <Header />
+      <div className='p-6 max-w-5xl mx-auto'>
+        <h1 className='text-2xl font-bold mb-6'>사용자 관리</h1>
 
-      <Card.Root>
-        <Card.Header>
-          <HStack
-            $css={{ justifyContent: 'space-between', alignItems: 'center' }}
-          >
-            <span className='text-lg font-semibold text-gray-700 shrink-0'>
-              사용자 목록
-            </span>
+        <Card.Root>
+          <Card.Header>
+            <HStack
+              $css={{ justifyContent: 'space-between', alignItems: 'center' }}
+            >
+              <span className='text-lg font-semibold text-gray-700 shrink-0'>
+                사용자 목록
+              </span>
 
-            <HStack $css={{ alignItems: 'center', gap: '$100' }}>
-              {/* 이름 검색 */}
-              <HStack
-                $css={{
-                  alignItems: 'center',
-                  gap: '10px',
-                  paddingLeft: '$150',
-                  border: '1px solid',
-                  borderColor: '$normal',
-                  borderRadius: '$300',
-                  width: '220px',
-                }}
-              >
-                <SearchOutlineIcon />
-                <TextInput
-                  placeholder='이름 검색'
+              <HStack $css={{ alignItems: 'center', gap: '$100' }}>
+                {/* 이름 검색 */}
+                <HStack
                   $css={{
-                    border: 'none',
-                    paddingInline: '$000',
-                    flex: 1,
-                    outline: 'none',
-                    boxShadow: 'none',
+                    alignItems: 'center',
+                    gap: '10px',
+                    paddingLeft: '$150',
+                    border: '1px solid',
+                    borderColor: '$normal',
+                    borderRadius: '$300',
+                    width: '220px',
                   }}
-                  onValueChange={(value) =>
-                    table.getColumn('user_name')?.setFilterValue(value)
-                  }
-                />
-              </HStack>
-
-              {/* 역할 필터 */}
-              <div className='w-40'>
-                <FilterSelect
-                  triggerLabel='역할'
-                  items={ROLE_ITEMS}
-                  value={roleFilter}
-                  size='md'
-                  onValueChange={(value) => {
-                    setRoleFilter(value as string[]);
-                    table.getColumn('user_role')?.setFilterValue(value);
-                  }}
-                />
-              </div>
-            </HStack>
-          </HStack>
-        </Card.Header>
-
-        <Card.Body $css={{ overflow: 'auto', padding: '$000' }}>
-          <Table.Root $css={{ width: '100%', tableLayout: 'fixed' }}>
-            <Table.ColumnGroup>
-              <Table.Column width='10%' />
-              <Table.Column width='20%' />
-              <Table.Column width='36%' />
-              <Table.Column width='14%' />
-              <Table.Column width='20%' />
-            </Table.ColumnGroup>
-            <Table.Header>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <Table.Row
-                  key={headerGroup.id}
-                  $css={{ backgroundColor: '$basic-gray-050' }}
                 >
-                  {headerGroup.headers.map((header) => (
-                    <Table.Heading
-                      key={header.id}
-                      onClick={header.column.getToggleSortingHandler()}
-                      $css={{
-                        cursor: header.column.getCanSort()
-                          ? 'pointer'
-                          : 'default',
-                        userSelect: 'none',
-                      }}
-                    >
-                      <HStack $css={{ gap: '$050', alignItems: 'center' }}>
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                        {header.column.getCanSort() &&
-                          (header.column.getIsSorted() === 'asc' ? (
-                            <ArrowDownOutlineIcon />
-                          ) : header.column.getIsSorted() === 'desc' ? (
-                            <ArrowUpOutlineIcon />
-                          ) : (
-                            <ArrowDownOutlineIcon color='none' />
-                          ))}
-                      </HStack>
-                    </Table.Heading>
-                  ))}
-                </Table.Row>
-              ))}
-            </Table.Header>
+                  <SearchOutlineIcon />
+                  <TextInput
+                    placeholder='이름 검색'
+                    $css={{
+                      border: 'none',
+                      paddingInline: '$000',
+                      flex: 1,
+                      outline: 'none',
+                      boxShadow: 'none',
+                    }}
+                    onValueChange={(value) =>
+                      table.getColumn('user_name')?.setFilterValue(value)
+                    }
+                  />
+                </HStack>
 
-            <Table.Body>
-              {loading ? (
-                <Table.Row>
-                  <Table.Cell
-                    colSpan={columns.length}
-                    $css={{ textAlign: 'center', height: '200px' }}
+                {/* 역할 필터 */}
+                <div className='w-40'>
+                  <FilterSelect
+                    triggerLabel='역할'
+                    items={ROLE_ITEMS}
+                    value={roleFilter}
+                    size='md'
+                    onValueChange={(value) => {
+                      setRoleFilter(value as string[]);
+                      table.getColumn('user_role')?.setFilterValue(value);
+                    }}
+                  />
+                </div>
+              </HStack>
+            </HStack>
+          </Card.Header>
+
+          <Card.Body $css={{ overflow: 'auto', padding: '$000' }}>
+            <Table.Root $css={{ width: '100%', tableLayout: 'fixed' }}>
+              <Table.ColumnGroup>
+                <Table.Column width='10%' />
+                <Table.Column width='20%' />
+                <Table.Column width='36%' />
+                <Table.Column width='14%' />
+                <Table.Column width='20%' />
+              </Table.ColumnGroup>
+              <Table.Header>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <Table.Row
+                    key={headerGroup.id}
+                    $css={{ backgroundColor: '$basic-gray-050' }}
                   >
-                    불러오는 중...
-                  </Table.Cell>
-                </Table.Row>
-              ) : table.getRowModel().rows.length ? (
-                table.getRowModel().rows.map((row) => (
-                  <Table.Row key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <Table.Cell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </Table.Cell>
+                    {headerGroup.headers.map((header) => (
+                      <Table.Heading
+                        key={header.id}
+                        onClick={header.column.getToggleSortingHandler()}
+                        $css={{
+                          cursor: header.column.getCanSort()
+                            ? 'pointer'
+                            : 'default',
+                          userSelect: 'none',
+                        }}
+                      >
+                        <HStack $css={{ gap: '$050', alignItems: 'center' }}>
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                          {header.column.getCanSort() &&
+                            (header.column.getIsSorted() === 'asc' ? (
+                              <ArrowDownOutlineIcon />
+                            ) : header.column.getIsSorted() === 'desc' ? (
+                              <ArrowUpOutlineIcon />
+                            ) : (
+                              <ArrowDownOutlineIcon color='none' />
+                            ))}
+                        </HStack>
+                      </Table.Heading>
                     ))}
                   </Table.Row>
-                ))
-              ) : (
-                <Table.Row>
-                  <Table.Cell
-                    colSpan={columns.length}
-                    $css={{ textAlign: 'center', height: '200px' }}
-                  >
-                    검색 결과가 없습니다.
-                  </Table.Cell>
-                </Table.Row>
-              )}
-            </Table.Body>
-          </Table.Root>
-
-          {/* 페이지네이션 */}
-          <Card.Footer
-            $css={{
-              position: 'relative',
-              display: 'flex',
-              justifyContent: 'center',
-            }}
-          >
-            <span className='absolute left-6 text-sm text-gray-500'>
-              총 {table.getFilteredRowModel().rows.length}명{' '}
-              {table.getFilteredRowModel().rows.length !== users.length && (
-                <span className='text-gray-400'>(전체 {users.length}명)</span>
-              )}
-            </span>
-
-            <Pagination.Root
-              totalPages={table.getPageCount()}
-              page={table.getState().pagination.pageIndex + 1}
-              onPageChange={(page) => table.setPageIndex(page - 1)}
-            >
-              <Pagination.Previous />
-              <Pagination.Items />
-              <Pagination.Next />
-            </Pagination.Root>
-
-            <Select.Root
-              value={table.getState().pagination.pageSize}
-              onValueChange={(value) => table.setPageSize(Number(value))}
-            >
-              <Select.TriggerPrimitive
-                $css={{ position: 'absolute' }}
-                style={{ right: 24, top: '50%', transform: 'translateY(-50%)' }}
-              >
-                <Select.ValuePrimitive>
-                  {(value) => `${value}개씩 보기`}
-                </Select.ValuePrimitive>
-                <Select.TriggerIconPrimitive />
-              </Select.TriggerPrimitive>
-              <Select.Popup>
-                {[5, 10, 20, 30].map((size) => (
-                  <Select.Item key={size} value={size}>
-                    {size}
-                  </Select.Item>
                 ))}
-              </Select.Popup>
-            </Select.Root>
-          </Card.Footer>
-        </Card.Body>
-      </Card.Root>
+              </Table.Header>
 
-      {/* 확인 Dialog */}
-      <Dialog.Root
-        open={dialog !== null}
-        onOpenChange={(open) => {
-          if (!open) setDialog(null);
-        }}
-      >
-        <Dialog.Popup>
-          <Dialog.Header>
-            <Dialog.Title>
-              {dialog?.type === 'delete' && '사용자 삭제'}
-              {dialog?.type === 'edit' && '사용자 수정'}
-            </Dialog.Title>
-          </Dialog.Header>
-          <Dialog.Body>
-            <Dialog.Description>
-              {dialog?.type === 'delete' &&
-                '정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'}
-              {dialog?.type === 'edit' && '사용자 정보를 수정하시겠습니까?'}
-            </Dialog.Description>
-          </Dialog.Body>
-          <Dialog.Footer style={{ marginLeft: 'auto' }}>
-            <Dialog.Close
-              render={
-                <button
-                  onClick={handleConfirm}
-                  className={`px-4 py-1.5 text-sm rounded text-white cursor-pointer mx-1 ${
-                    dialog?.type === 'delete'
-                      ? 'bg-red-500 hover:bg-red-600'
-                      : 'bg-blue-600 hover:bg-blue-700'
-                  }`}
+              <Table.Body>
+                {loading ? (
+                  <Table.Row>
+                    <Table.Cell
+                      colSpan={columns.length}
+                      $css={{ textAlign: 'center', height: '200px' }}
+                    >
+                      불러오는 중...
+                    </Table.Cell>
+                  </Table.Row>
+                ) : table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <Table.Row key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <Table.Cell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </Table.Cell>
+                      ))}
+                    </Table.Row>
+                  ))
+                ) : (
+                  <Table.Row>
+                    <Table.Cell
+                      colSpan={columns.length}
+                      $css={{ textAlign: 'center', height: '200px' }}
+                    >
+                      검색 결과가 없습니다.
+                    </Table.Cell>
+                  </Table.Row>
+                )}
+              </Table.Body>
+            </Table.Root>
+
+            {/* 페이지네이션 */}
+            <Card.Footer
+              $css={{
+                position: 'relative',
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              <span className='absolute left-6 text-sm text-gray-500'>
+                총 {table.getFilteredRowModel().rows.length}명{' '}
+                {table.getFilteredRowModel().rows.length !== users.length && (
+                  <span className='text-gray-400'>(전체 {users.length}명)</span>
+                )}
+              </span>
+
+              <Pagination.Root
+                totalPages={table.getPageCount()}
+                page={table.getState().pagination.pageIndex + 1}
+                onPageChange={(page) => table.setPageIndex(page - 1)}
+              >
+                <Pagination.Previous />
+                <Pagination.Items />
+                <Pagination.Next />
+              </Pagination.Root>
+
+              <Select.Root
+                value={table.getState().pagination.pageSize}
+                onValueChange={(value) => table.setPageSize(Number(value))}
+              >
+                <Select.TriggerPrimitive
+                  $css={{ position: 'absolute' }}
+                  style={{
+                    right: 24,
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                  }}
                 >
-                  확인
-                </button>
-              }
-            />
-            <Dialog.Close
-              render={
-                <button className='px-4 py-1.5 text-sm rounded border border-gray-300 hover:bg-gray-100 cursor-pointer'>
-                  취소
-                </button>
-              }
-            />
-          </Dialog.Footer>
-        </Dialog.Popup>
-      </Dialog.Root>
+                  <Select.ValuePrimitive>
+                    {(value) => `${value}개씩 보기`}
+                  </Select.ValuePrimitive>
+                  <Select.TriggerIconPrimitive />
+                </Select.TriggerPrimitive>
+                <Select.Popup>
+                  {[5, 10, 20, 30].map((size) => (
+                    <Select.Item key={size} value={size}>
+                      {size}
+                    </Select.Item>
+                  ))}
+                </Select.Popup>
+              </Select.Root>
+            </Card.Footer>
+          </Card.Body>
+        </Card.Root>
+
+        {/* 확인 Dialog */}
+        <Dialog.Root
+          open={dialog !== null}
+          onOpenChange={(open) => {
+            if (!open) setDialog(null);
+          }}
+        >
+          <Dialog.Popup>
+            <Dialog.Header>
+              <Dialog.Title>
+                {dialog?.type === 'delete' && '사용자 삭제'}
+                {dialog?.type === 'edit' && '사용자 수정'}
+              </Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Dialog.Description>
+                {dialog?.type === 'delete' &&
+                  '정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'}
+                {dialog?.type === 'edit' && '사용자 정보를 수정하시겠습니까?'}
+              </Dialog.Description>
+            </Dialog.Body>
+            <Dialog.Footer style={{ marginLeft: 'auto' }}>
+              <Dialog.Close
+                render={
+                  <button
+                    onClick={handleConfirm}
+                    className={`px-4 py-1.5 text-sm rounded text-white cursor-pointer mx-1 ${
+                      dialog?.type === 'delete'
+                        ? 'bg-red-500 hover:bg-red-600'
+                        : 'bg-blue-600 hover:bg-blue-700'
+                    }`}
+                  >
+                    확인
+                  </button>
+                }
+              />
+              <Dialog.Close
+                render={
+                  <button className='px-4 py-1.5 text-sm rounded border border-gray-300 hover:bg-gray-100 cursor-pointer'>
+                    취소
+                  </button>
+                }
+              />
+            </Dialog.Footer>
+          </Dialog.Popup>
+        </Dialog.Root>
+      </div>
     </div>
   );
 }

--- a/src/pages/admin/ProductsManagePage.test.tsx
+++ b/src/pages/admin/ProductsManagePage.test.tsx
@@ -18,6 +18,10 @@ vi.mock('../../lib/toastManager', () => ({
   toastManager: { add: vi.fn() },
 }));
 
+vi.mock('../../components/Header', () => ({
+  default: () => null,
+}));
+
 const mockProducts = [
   {
     id: 1,

--- a/src/pages/admin/ProductsManagePage.tsx
+++ b/src/pages/admin/ProductsManagePage.tsx
@@ -33,6 +33,7 @@ import {
 import type { Product, ProductFormData } from '../../types';
 import { toastManager } from '../../lib/toastManager';
 import { productAPI } from '../../api/index';
+import Header from '../../components/Header';
 
 // 상수
 const CATEGORIES = ['전체', '식품', '생필품', '전자제품'];
@@ -448,421 +449,433 @@ export default function ProductsManagePage() {
   });
 
   return (
-    <div className='p-6 max-w-5xl mx-auto'>
-      <h1 className='text-2xl font-bold mb-6'>상품 관리</h1>
+    <div className='min-h-screen bg-gray-50'>
+      <Header />
+      <div className='p-6 max-w-5xl mx-auto'>
+        <h1 className='text-2xl font-bold mb-6'>상품 관리</h1>
 
-      {/* 테이블 */}
-      <Card.Root>
-        <Card.Header>
-          <HStack
-            $css={{ justifyContent: 'space-between', alignItems: 'center' }}
-          >
-            <span className='text-lg font-semibold text-gray-700 shrink-0'>
-              상품 목록
-            </span>
+        {/* 테이블 */}
+        <Card.Root>
+          <Card.Header>
+            <HStack
+              $css={{ justifyContent: 'space-between', alignItems: 'center' }}
+            >
+              <span className='text-lg font-semibold text-gray-700 shrink-0'>
+                상품 목록
+              </span>
 
-            <HStack $css={{ alignItems: 'center', gap: '$100' }}>
-              {/* 검색 */}
-              <HStack
-                $css={{
-                  alignItems: 'center',
-                  gap: '10px',
-                  paddingLeft: '$150',
-                  border: '1px solid',
-                  borderColor: '$normal',
-                  borderRadius: '$300',
-                  width: '220px',
-                }}
-              >
-                <SearchOutlineIcon />
-                <TextInput
-                  placeholder='상품명 검색'
+              <HStack $css={{ alignItems: 'center', gap: '$100' }}>
+                {/* 검색 */}
+                <HStack
                   $css={{
-                    border: 'none',
-                    paddingInline: '$000',
-                    flex: 1,
-                    outline: 'none',
-                    boxShadow: 'none',
+                    alignItems: 'center',
+                    gap: '10px',
+                    paddingLeft: '$150',
+                    border: '1px solid',
+                    borderColor: '$normal',
+                    borderRadius: '$300',
+                    width: '220px',
                   }}
-                  onValueChange={(value) =>
-                    table.getColumn('product_name')?.setFilterValue(value)
-                  }
-                />
-              </HStack>
-
-              {/* 카테고리 필터 */}
-              <div className='w-50'>
-                <FilterSelect
-                  triggerLabel='카테고리'
-                  items={CATEGORY_ITEMS}
-                  value={categoryFilter}
-                  size='md'
-                  onValueChange={(value) => {
-                    setCategoryFilter(value as string[]);
-                    table.getColumn('product_category')?.setFilterValue(value);
-                  }}
-                />
-              </div>
-
-              {/* 상품 추가 버튼 */}
-              <button
-                onClick={() => {
-                  setEditingId(null);
-                  setShowAddForm(true);
-                }}
-                className='h-8 px-3 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors cursor-pointer flex items-center gap-1 whitespace-nowrap'
-              >
-                <PlusOutlineIcon size='16px' />
-                상품 추가
-              </button>
-            </HStack>
-          </HStack>
-        </Card.Header>
-        {/* 상품 추가 폼 */}
-        {showAddForm && (
-          <div className='w-full px-4 py-3 border border-gray-200 rounded-lg bg-gray-50 flex flex-col gap-3'>
-            <div className='flex flex-wrap gap-4 items-end'>
-              <label className='flex flex-col gap-1 text-sm w-52'>
-                <span className='text-gray-600 font-medium'>상품명</span>
-                <input
-                  placeholder='상품명'
-                  type='text'
-                  value={newProduct.product_name}
-                  onChange={(e) =>
-                    setNewProduct((prev) => ({
-                      ...prev,
-                      product_name: e.target.value,
-                    }))
-                  }
-                  className='border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-gray-400'
-                />
-              </label>
-              <label className='flex flex-col gap-1 text-sm w-40'>
-                <span className='text-gray-600 font-medium'>가격</span>
-                <input
-                  type='number'
-                  placeholder='0'
-                  min={1}
-                  value={newProduct.product_price || ''}
-                  onChange={(e) =>
-                    setNewProduct((prev) => ({
-                      ...prev,
-                      product_price: Number(e.target.value),
-                    }))
-                  }
-                  className='border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-gray-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
-                />
-              </label>
-              <label className='flex flex-col gap-1 text-sm w-40'>
-                <span className='text-gray-600 font-medium'>카테고리</span>
-                <Select.Root
-                  placeholder='선택'
-                  items={CATEGORY_ITEMS}
-                  value={newProduct.product_category}
-                  onValueChange={(value) =>
-                    setNewProduct((prev) => ({
-                      ...prev,
-                      product_category: value as string,
-                    }))
-                  }
-                  size='md'
                 >
-                  <Select.Trigger />
-                  <Select.Popup>
-                    {CATEGORY_ITEMS.map((item) => (
-                      <Select.Item key={item.value} value={item.value}>
-                        {item.label}{' '}
-                      </Select.Item>
-                    ))}
-                  </Select.Popup>
-                </Select.Root>
-              </label>
-              <label className='flex flex-col gap-1 text-sm w-32'>
-                <span className='text-gray-600 font-medium'>재고</span>
-                <input
-                  type='number'
-                  min={0}
-                  placeholder='0'
-                  value={newProduct.stock || ''}
-                  onChange={(e) =>
-                    setNewProduct((prev) => ({
-                      ...prev,
-                      stock: Number(e.target.value),
-                    }))
-                  }
-                  className='border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-gray-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
-                />
-              </label>
-              <div className='ml-auto flex gap-2 items-end'>
-                <button
-                  onClick={handleAddClick}
-                  className='px-4 py-1.5 bg-green-600 text-white text-sm rounded hover:bg-green-700 transition-colors cursor-pointer'
-                >
-                  추가
-                </button>
+                  <SearchOutlineIcon />
+                  <TextInput
+                    placeholder='상품명 검색'
+                    $css={{
+                      border: 'none',
+                      paddingInline: '$000',
+                      flex: 1,
+                      outline: 'none',
+                      boxShadow: 'none',
+                    }}
+                    onValueChange={(value) =>
+                      table.getColumn('product_name')?.setFilterValue(value)
+                    }
+                  />
+                </HStack>
+
+                {/* 카테고리 필터 */}
+                <div className='w-50'>
+                  <FilterSelect
+                    triggerLabel='카테고리'
+                    items={CATEGORY_ITEMS}
+                    value={categoryFilter}
+                    size='md'
+                    onValueChange={(value) => {
+                      setCategoryFilter(value as string[]);
+                      table
+                        .getColumn('product_category')
+                        ?.setFilterValue(value);
+                    }}
+                  />
+                </div>
+
+                {/* 상품 추가 버튼 */}
                 <button
                   onClick={() => {
-                    setShowAddForm(false);
-                    setNewProduct(EMPTY_FORM);
+                    setEditingId(null);
+                    setShowAddForm(true);
                   }}
-                  className='px-4 py-1.5 text-sm rounded cursor-pointer flex items-center gap-1 bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors'
+                  className='h-8 px-3 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors cursor-pointer flex items-center gap-1 whitespace-nowrap'
                 >
-                  취소
+                  <PlusOutlineIcon size='16px' />
+                  상품 추가
                 </button>
+              </HStack>
+            </HStack>
+          </Card.Header>
+          {/* 상품 추가 폼 */}
+          {showAddForm && (
+            <div className='w-full px-4 py-3 border border-gray-200 rounded-lg bg-gray-50 flex flex-col gap-3'>
+              <div className='flex flex-wrap gap-4 items-end'>
+                <label className='flex flex-col gap-1 text-sm w-52'>
+                  <span className='text-gray-600 font-medium'>상품명</span>
+                  <input
+                    placeholder='상품명'
+                    type='text'
+                    value={newProduct.product_name}
+                    onChange={(e) =>
+                      setNewProduct((prev) => ({
+                        ...prev,
+                        product_name: e.target.value,
+                      }))
+                    }
+                    className='border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-gray-400'
+                  />
+                </label>
+                <label className='flex flex-col gap-1 text-sm w-40'>
+                  <span className='text-gray-600 font-medium'>가격</span>
+                  <input
+                    type='number'
+                    placeholder='0'
+                    min={1}
+                    value={newProduct.product_price || ''}
+                    onChange={(e) =>
+                      setNewProduct((prev) => ({
+                        ...prev,
+                        product_price: Number(e.target.value),
+                      }))
+                    }
+                    className='border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-gray-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
+                  />
+                </label>
+                <label className='flex flex-col gap-1 text-sm w-40'>
+                  <span className='text-gray-600 font-medium'>카테고리</span>
+                  <Select.Root
+                    placeholder='선택'
+                    items={CATEGORY_ITEMS}
+                    value={newProduct.product_category}
+                    onValueChange={(value) =>
+                      setNewProduct((prev) => ({
+                        ...prev,
+                        product_category: value as string,
+                      }))
+                    }
+                    size='md'
+                  >
+                    <Select.Trigger />
+                    <Select.Popup>
+                      {CATEGORY_ITEMS.map((item) => (
+                        <Select.Item key={item.value} value={item.value}>
+                          {item.label}{' '}
+                        </Select.Item>
+                      ))}
+                    </Select.Popup>
+                  </Select.Root>
+                </label>
+                <label className='flex flex-col gap-1 text-sm w-32'>
+                  <span className='text-gray-600 font-medium'>재고</span>
+                  <input
+                    type='number'
+                    min={0}
+                    placeholder='0'
+                    value={newProduct.stock || ''}
+                    onChange={(e) =>
+                      setNewProduct((prev) => ({
+                        ...prev,
+                        stock: Number(e.target.value),
+                      }))
+                    }
+                    className='border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-gray-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
+                  />
+                </label>
+                <div className='ml-auto flex gap-2 items-end'>
+                  <button
+                    onClick={handleAddClick}
+                    className='px-4 py-1.5 bg-green-600 text-white text-sm rounded hover:bg-green-700 transition-colors cursor-pointer'
+                  >
+                    추가
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowAddForm(false);
+                      setNewProduct(EMPTY_FORM);
+                    }}
+                    className='px-4 py-1.5 text-sm rounded cursor-pointer flex items-center gap-1 bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors'
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+
+              <div className='flex flex-col gap-1 text-sm w-full'>
+                <span className='text-gray-600 font-medium'>상품설명</span>
+                <textarea
+                  placeholder='상품 설명을 입력하세요'
+                  rows={2}
+                  value={newProduct.product_detail}
+                  onChange={(e) =>
+                    setNewProduct((prev) => ({
+                      ...prev,
+                      product_detail: e.target.value,
+                    }))
+                  }
+                  className='border border-gray-300 rounded px-2 py-1 resize-none focus:outline-none focus:ring-2 focus:ring-gray-400'
+                />
               </div>
             </div>
-
-            <div className='flex flex-col gap-1 text-sm w-full'>
-              <span className='text-gray-600 font-medium'>상품설명</span>
-              <textarea
-                placeholder='상품 설명을 입력하세요'
-                rows={2}
-                value={newProduct.product_detail}
-                onChange={(e) =>
-                  setNewProduct((prev) => ({
-                    ...prev,
-                    product_detail: e.target.value,
-                  }))
-                }
-                className='border border-gray-300 rounded px-2 py-1 resize-none focus:outline-none focus:ring-2 focus:ring-gray-400'
-              />
-            </div>
-          </div>
-        )}
-        <Card.Body $css={{ overflow: 'auto', padding: '$000' }}>
-          <Table.Root $css={{ width: '100%', tableLayout: 'fixed' }}>
-            <Table.ColumnGroup>
-              <Table.Column width='10%' />
-              <Table.Column width='26%' />
-              <Table.Column width='16%' />
-              <Table.Column width='16%' />
-              <Table.Column width='12%' />
-              <Table.Column width='20%' />
-            </Table.ColumnGroup>
-            <Table.Header>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <Table.Row
-                  key={headerGroup.id}
-                  $css={{ backgroundColor: '$basic-gray-050' }}
-                >
-                  {headerGroup.headers.map((header) => (
-                    <Table.Heading
-                      key={header.id}
-                      onClick={header.column.getToggleSortingHandler()}
-                      $css={{
-                        cursor: header.column.getCanSort()
-                          ? 'pointer'
-                          : 'default',
-                        userSelect: 'none',
-                      }}
-                    >
-                      <HStack $css={{ gap: '$050', alignItems: 'center' }}>
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                        {header.column.getCanSort() &&
-                          (header.column.getIsSorted() === 'asc' ? (
-                            <ArrowDownOutlineIcon />
-                          ) : header.column.getIsSorted() === 'desc' ? (
-                            <ArrowUpOutlineIcon />
-                          ) : (
-                            <ArrowDownOutlineIcon color='none' />
-                          ))}
-                      </HStack>
-                    </Table.Heading>
-                  ))}
-                </Table.Row>
-              ))}
-            </Table.Header>
-
-            <Table.Body>
-              {loading ? (
-                <Table.Row>
-                  <Table.Cell
-                    colSpan={columns.length}
-                    $css={{ textAlign: 'center', height: '200px' }}
+          )}
+          <Card.Body $css={{ overflow: 'auto', padding: '$000' }}>
+            <Table.Root $css={{ width: '100%', tableLayout: 'fixed' }}>
+              <Table.ColumnGroup>
+                <Table.Column width='10%' />
+                <Table.Column width='26%' />
+                <Table.Column width='16%' />
+                <Table.Column width='16%' />
+                <Table.Column width='12%' />
+                <Table.Column width='20%' />
+              </Table.ColumnGroup>
+              <Table.Header>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <Table.Row
+                    key={headerGroup.id}
+                    $css={{ backgroundColor: '$basic-gray-050' }}
                   >
-                    불러오는 중...
-                  </Table.Cell>
-                </Table.Row>
-              ) : table.getRowModel().rows.length ? (
-                table.getRowModel().rows.map((row) => (
-                  <Fragment key={row.id}>
-                    <Table.Row
-                      key={row.id}
-                      $css={{ cursor: 'pointer' }}
-                      onClick={(e) => {
-                        if (
-                          (e.target as HTMLElement).closest(
-                            'button, input, textarea, [role="combobox"], [role="option"], [role="listbox"]',
-                          )
-                        )
-                          return;
-                        toggleExpand(row.original.id);
-                      }}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <Table.Cell key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )}
-                        </Table.Cell>
-                      ))}
-                    </Table.Row>
-                    <Table.Row key={`${row.id}-desc`}>
-                      <Table.Cell
-                        colSpan={columns.length}
-                        $css={{ padding: '$000' }}
+                    {headerGroup.headers.map((header) => (
+                      <Table.Heading
+                        key={header.id}
+                        onClick={header.column.getToggleSortingHandler()}
+                        $css={{
+                          cursor: header.column.getCanSort()
+                            ? 'pointer'
+                            : 'default',
+                          userSelect: 'none',
+                        }}
                       >
-                        <Collapsible.Root
-                          open={expandedRows.has(row.original.id)}
-                        >
-                          <Collapsible.Panel>
-                            <div className='flex flex-col gap-1 px-4 py-3 bg-gray-50 border-t border-gray-100'>
-                              <span className='text-xs font-medium text-gray-500'>
-                                상품설명
-                              </span>
-                              {editingId === row.original.id ? (
-                                <textarea
-                                  value={editingDataRef.current.product_detail}
-                                  onChange={(e) =>
-                                    setEditingData((prev) => ({
-                                      ...prev,
-                                      product_detail: e.target.value,
-                                    }))
-                                  }
-                                  rows={2}
-                                  className='border border-gray-300 rounded px-2 py-1 w-full resize-none focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm'
-                                />
-                              ) : (
-                                <span className='text-sm text-gray-700'>
-                                  {row.original.product_detail}
-                                </span>
-                              )}
-                            </div>
-                          </Collapsible.Panel>
-                        </Collapsible.Root>
-                      </Table.Cell>
-                    </Table.Row>
-                  </Fragment>
-                ))
-              ) : (
-                <Table.Row>
-                  <Table.Cell
-                    colSpan={columns.length}
-                    $css={{ textAlign: 'center', height: '200px' }}
-                  >
-                    검색 결과가 없습니다.
-                  </Table.Cell>
-                </Table.Row>
-              )}
-            </Table.Body>
-          </Table.Root>
-
-          {/* 페이지네이션 */}
-          <Card.Footer
-            $css={{
-              position: 'relative',
-              display: 'flex',
-              justifyContent: 'center',
-            }}
-          >
-            {/* 총 상품 수 */}
-            <span className='absolute left-6 text-sm text-gray-500'>
-              총 {table.getFilteredRowModel().rows.length}개{' '}
-              {table.getFilteredRowModel().rows.length !== products.length && (
-                <span className='text-gray-400'>
-                  {' '}
-                  (전체 {products.length}개)
-                </span>
-              )}
-            </span>
-
-            <Pagination.Root
-              totalPages={table.getPageCount()}
-              page={table.getState().pagination.pageIndex + 1}
-              onPageChange={(page) => table.setPageIndex(page - 1)}
-            >
-              <Pagination.Previous />
-              <Pagination.Items />
-              <Pagination.Next />
-            </Pagination.Root>
-
-            <Select.Root
-              value={table.getState().pagination.pageSize}
-              onValueChange={(value) => table.setPageSize(Number(value))}
-            >
-              <Select.TriggerPrimitive
-                $css={{ position: 'absolute' }}
-                style={{ right: 24, top: '50%', transform: 'translateY(-50%)' }}
-              >
-                <Select.ValuePrimitive>
-                  {(value) => `${value}개씩 보기`}
-                </Select.ValuePrimitive>
-                <Select.TriggerIconPrimitive />
-              </Select.TriggerPrimitive>
-              <Select.Popup>
-                {[5, 10, 20, 30].map((size) => (
-                  <Select.Item key={size} value={size}>
-                    {size}
-                  </Select.Item>
+                        <HStack $css={{ gap: '$050', alignItems: 'center' }}>
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                          {header.column.getCanSort() &&
+                            (header.column.getIsSorted() === 'asc' ? (
+                              <ArrowDownOutlineIcon />
+                            ) : header.column.getIsSorted() === 'desc' ? (
+                              <ArrowUpOutlineIcon />
+                            ) : (
+                              <ArrowDownOutlineIcon color='none' />
+                            ))}
+                        </HStack>
+                      </Table.Heading>
+                    ))}
+                  </Table.Row>
                 ))}
-              </Select.Popup>
-            </Select.Root>
-          </Card.Footer>
-        </Card.Body>
-      </Card.Root>
+              </Table.Header>
 
-      {/* 확인 Dialog */}
-      <Dialog.Root
-        open={dialog !== null}
-        onOpenChange={(open) => {
-          if (!open) setDialog(null);
-        }}
-      >
-        <Dialog.Popup>
-          <Dialog.Header>
-            <Dialog.Title>
-              {dialog?.type === 'delete' && '상품 삭제'}
-              {dialog?.type === 'edit' && '상품 수정'}
-              {dialog?.type === 'add' && '상품 추가'}
-            </Dialog.Title>
-          </Dialog.Header>
-          <Dialog.Body>
-            <Dialog.Description>
-              {dialog?.type === 'delete' &&
-                '정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'}
-              {dialog?.type === 'edit' && '상품 정보를 수정하시겠습니까?'}
-              {dialog?.type === 'add' && '새 상품을 추가하시겠습니까?'}
-            </Dialog.Description>
-          </Dialog.Body>
-          <Dialog.Footer style={{ marginLeft: 'auto' }}>
-            <Dialog.Close
-              render={
-                <button
-                  onClick={handleConfirm}
-                  className={`px-4 py-1.5 text-sm rounded text-white cursor-pointer mx-1 ${
-                    dialog?.type === 'delete'
-                      ? 'bg-red-500 hover:bg-red-600'
-                      : 'bg-blue-600 hover:bg-blue-700'
-                  }`}
+              <Table.Body>
+                {loading ? (
+                  <Table.Row>
+                    <Table.Cell
+                      colSpan={columns.length}
+                      $css={{ textAlign: 'center', height: '200px' }}
+                    >
+                      불러오는 중...
+                    </Table.Cell>
+                  </Table.Row>
+                ) : table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <Fragment key={row.id}>
+                      <Table.Row
+                        key={row.id}
+                        $css={{ cursor: 'pointer' }}
+                        onClick={(e) => {
+                          if (
+                            (e.target as HTMLElement).closest(
+                              'button, input, textarea, [role="combobox"], [role="option"], [role="listbox"]',
+                            )
+                          )
+                            return;
+                          toggleExpand(row.original.id);
+                        }}
+                      >
+                        {row.getVisibleCells().map((cell) => (
+                          <Table.Cell key={cell.id}>
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )}
+                          </Table.Cell>
+                        ))}
+                      </Table.Row>
+                      <Table.Row key={`${row.id}-desc`}>
+                        <Table.Cell
+                          colSpan={columns.length}
+                          $css={{ padding: '$000' }}
+                        >
+                          <Collapsible.Root
+                            open={expandedRows.has(row.original.id)}
+                          >
+                            <Collapsible.Panel>
+                              <div className='flex flex-col gap-1 px-4 py-3 bg-gray-50 border-t border-gray-100'>
+                                <span className='text-xs font-medium text-gray-500'>
+                                  상품설명
+                                </span>
+                                {editingId === row.original.id ? (
+                                  <textarea
+                                    value={
+                                      editingDataRef.current.product_detail
+                                    }
+                                    onChange={(e) =>
+                                      setEditingData((prev) => ({
+                                        ...prev,
+                                        product_detail: e.target.value,
+                                      }))
+                                    }
+                                    rows={2}
+                                    className='border border-gray-300 rounded px-2 py-1 w-full resize-none focus:outline-none focus:ring-2 focus:ring-blue-400 text-sm'
+                                  />
+                                ) : (
+                                  <span className='text-sm text-gray-700'>
+                                    {row.original.product_detail}
+                                  </span>
+                                )}
+                              </div>
+                            </Collapsible.Panel>
+                          </Collapsible.Root>
+                        </Table.Cell>
+                      </Table.Row>
+                    </Fragment>
+                  ))
+                ) : (
+                  <Table.Row>
+                    <Table.Cell
+                      colSpan={columns.length}
+                      $css={{ textAlign: 'center', height: '200px' }}
+                    >
+                      검색 결과가 없습니다.
+                    </Table.Cell>
+                  </Table.Row>
+                )}
+              </Table.Body>
+            </Table.Root>
+
+            {/* 페이지네이션 */}
+            <Card.Footer
+              $css={{
+                position: 'relative',
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              {/* 총 상품 수 */}
+              <span className='absolute left-6 text-sm text-gray-500'>
+                총 {table.getFilteredRowModel().rows.length}개{' '}
+                {table.getFilteredRowModel().rows.length !==
+                  products.length && (
+                  <span className='text-gray-400'>
+                    {' '}
+                    (전체 {products.length}개)
+                  </span>
+                )}
+              </span>
+
+              <Pagination.Root
+                totalPages={table.getPageCount()}
+                page={table.getState().pagination.pageIndex + 1}
+                onPageChange={(page) => table.setPageIndex(page - 1)}
+              >
+                <Pagination.Previous />
+                <Pagination.Items />
+                <Pagination.Next />
+              </Pagination.Root>
+
+              <Select.Root
+                value={table.getState().pagination.pageSize}
+                onValueChange={(value) => table.setPageSize(Number(value))}
+              >
+                <Select.TriggerPrimitive
+                  $css={{ position: 'absolute' }}
+                  style={{
+                    right: 24,
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                  }}
                 >
-                  확인
-                </button>
-              }
-            />
-            <Dialog.Close
-              render={
-                <button className='px-4 py-1.5 text-sm rounded border border-gray-300 hover:bg-gray-100 cursor-pointer'>
-                  취소
-                </button>
-              }
-            />
-          </Dialog.Footer>
-        </Dialog.Popup>
-      </Dialog.Root>
+                  <Select.ValuePrimitive>
+                    {(value) => `${value}개씩 보기`}
+                  </Select.ValuePrimitive>
+                  <Select.TriggerIconPrimitive />
+                </Select.TriggerPrimitive>
+                <Select.Popup>
+                  {[5, 10, 20, 30].map((size) => (
+                    <Select.Item key={size} value={size}>
+                      {size}
+                    </Select.Item>
+                  ))}
+                </Select.Popup>
+              </Select.Root>
+            </Card.Footer>
+          </Card.Body>
+        </Card.Root>
+
+        {/* 확인 Dialog */}
+        <Dialog.Root
+          open={dialog !== null}
+          onOpenChange={(open) => {
+            if (!open) setDialog(null);
+          }}
+        >
+          <Dialog.Popup>
+            <Dialog.Header>
+              <Dialog.Title>
+                {dialog?.type === 'delete' && '상품 삭제'}
+                {dialog?.type === 'edit' && '상품 수정'}
+                {dialog?.type === 'add' && '상품 추가'}
+              </Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Dialog.Description>
+                {dialog?.type === 'delete' &&
+                  '정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.'}
+                {dialog?.type === 'edit' && '상품 정보를 수정하시겠습니까?'}
+                {dialog?.type === 'add' && '새 상품을 추가하시겠습니까?'}
+              </Dialog.Description>
+            </Dialog.Body>
+            <Dialog.Footer style={{ marginLeft: 'auto' }}>
+              <Dialog.Close
+                render={
+                  <button
+                    onClick={handleConfirm}
+                    className={`px-4 py-1.5 text-sm rounded text-white cursor-pointer mx-1 ${
+                      dialog?.type === 'delete'
+                        ? 'bg-red-500 hover:bg-red-600'
+                        : 'bg-blue-600 hover:bg-blue-700'
+                    }`}
+                  >
+                    확인
+                  </button>
+                }
+              />
+              <Dialog.Close
+                render={
+                  <button className='px-4 py-1.5 text-sm rounded border border-gray-300 hover:bg-gray-100 cursor-pointer'>
+                    취소
+                  </button>
+                }
+              />
+            </Dialog.Footer>
+          </Dialog.Popup>
+        </Dialog.Root>
+      </div>
     </div>
   );
 }

--- a/src/pages/auth/LoginPage.test.tsx
+++ b/src/pages/auth/LoginPage.test.tsx
@@ -12,7 +12,16 @@ vi.mock('react-router-dom', async () => {
 });
 
 vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: () => ({ login: mockLogin }),
+  useAuth: () => ({
+    login: mockLogin,
+    user: null,
+    isAdmin: false,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/Header', () => ({
+  default: () => null,
 }));
 
 const renderLoginPage = () =>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { Card, TextInput, Button } from '@vapor-ui/core';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useState } from 'react';
@@ -44,9 +45,9 @@ export default function LoginPage() {
    * - 로그인 버튼
    */
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='flex min-h-screen flex-col bg-gray-50'>
       <Header />
-      <div className='flex min-h-screen items-center justify-center bg-gray-50'>
+      <div className='flex flex-1 items-center justify-center'>
         <div className='relative w-full max-w-sm px-4'>
           {/* 사이트 명 */}
           <div className='mb-8 text-center'>
@@ -56,74 +57,71 @@ export default function LoginPage() {
           </div>
 
           {/* 카드 */}
-          <div className='rounded-3xl bg-white/90 p-8 shadow-xl shadow-stone-200/60 ring-1 ring-stone-100 backdrop-blur-sm'>
-            <h1 className='mb-7 text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
-              LOGIN
-            </h1>
-
-            <form
-              onSubmit={handleSubmit}
-              className='flex w-full flex-col gap-5'
-            >
-              {/* 이메일 */}
-              <div className='flex flex-col gap-1'>
-                <input
-                  type='email'
-                  placeholder='이메일'
-                  value={userEmail}
-                  onChange={(e) => setUserEmail(e.target.value)}
-                  required
-                  className='w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100'
-                />
-              </div>
-
-              {/* 패스워드 */}
-              <div className='flex flex-col gap-1'>
-                <input
-                  type='password'
-                  placeholder='비밀번호'
-                  value={userPassword}
-                  onChange={(e) => setUserPassword(e.target.value)}
-                  required
-                  className='w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100'
-                />
-              </div>
-
-              {/* 에러 메시지 */}
-              {error && (
-                <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
-                  <span className='text-red-400'>⚠</span>
-                  <p className='text-sm text-red-600'>{error}</p>
+          <Card.Root>
+            <Card.Header>
+              <h1 className='text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
+                LOGIN
+              </h1>
+            </Card.Header>
+            <Card.Body>
+              <form
+                onSubmit={handleSubmit}
+                className='flex w-full flex-col gap-5'
+              >
+                {/* 이메일 */}
+                <div className='flex flex-col gap-1'>
+                  <TextInput
+                    type='email'
+                    placeholder='이메일'
+                    value={userEmail}
+                    onChange={(e) => setUserEmail(e.target.value)}
+                    required
+                  />
                 </div>
-              )}
 
-              {/* 로그인 버튼 */}
-              <button
-                type='submit'
-                disabled={isLoading}
-                className='mt-1 w-full rounded-xl bg-stone-800 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-stone-700 disabled:opacity-50 hover:cursor-pointer'
-              >
-                {isLoading ? '로그인 중...' : '로그인'}
-              </button>
-            </form>
+                {/* 패스워드 */}
+                <div className='flex flex-col gap-1'>
+                  <TextInput
+                    type='password'
+                    placeholder='비밀번호'
+                    value={userPassword}
+                    onChange={(e) => setUserPassword(e.target.value)}
+                    invalid={!!error}
+                    required
+                  />
+                </div>
 
-            {/* 구분선 */}
-            <div className='my-6 flex items-center gap-3'>
-              <div className='h-px flex-1 bg-stone-300' />
-              <span className='text-xs tracking-widest text-stone-400'>OR</span>
-              <div className='h-px flex-1 bg-stone-300' />
-            </div>
+                {/* 에러 메시지 */}
+                {error && (
+                  <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
+                    <span className='text-red-400'>⚠</span>
+                    <p className='text-sm text-red-600'>{error}</p>
+                  </div>
+                )}
 
-            {/* 회원가입 링크 */}
-            <p className='text-center text-sm'>
-              <Link
-                to='/signup'
-                className='font-semibold text-stone-500 underline-offset-2 hover:underline'
-              >
-                회원가입
-              </Link>
-            </p>
-          </div>
+                {/* 로그인 버튼 */}
+                <Button
+                  type='submit'
+                  disabled={isLoading}
+                  className='mt-1 w-full'
+                >
+                  {isLoading ? '로그인 중...' : '로그인'}
+                </Button>
+              </form>
+            </Card.Body>
+            <Card.Footer>
+              <div className='flex flex-col gap-4'>
+                <p className='text-center text-sm'>
+                  <Link
+                    to='/signup'
+                    className='font-semibold text-stone-500 underline-offset-2 hover:underline'
+                  >
+                    회원가입
+                  </Link>
+                </p>
+              </div>
+            </Card.Footer>
+          </Card.Root>
         </div>
       </div>
     </div>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,13 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useState } from 'react';
+import Header from '../../components/Header';
 
+/**
+ * 로그인 페이지
+ * - 이메일, 비밀번호 입력 폼
+ * - 로그인 API 호출 후 메인 페이지로 리다이렉트
+ */
 export default function LoginPage() {
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -11,6 +17,11 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
+  /**
+   * 컴포넌트 마운트 시 로컬 스토리지에서 토큰과 유저 정보 확인
+   * - 토큰이 유효하면 로그인 상태 유지
+   * - 토큰이 없거나 유효하지 않으면 로그인 상태 초기화
+   */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -18,8 +29,6 @@ export default function LoginPage() {
 
     try {
       await login(userEmail, userPassword);
-      const stored = localStorage.getItem('user');
-      const user = stored ? JSON.parse(stored) : null;
       navigate('/');
     } catch {
       setError('이메일 또는 패스워드가 올바르지 않습니다.');
@@ -28,87 +37,93 @@ export default function LoginPage() {
     }
   };
 
+  /**
+   * 로그인 폼
+   * - 이메일, 비밀번호 입력 필드
+   * - 에러 메시지 표시
+   * - 로그인 버튼
+   */
   return (
-    <div
-      className='relative flex min-h-screen items-center justify-center overflow-hidden'
-      style={{
-        background:
-          'linear-gradient(135deg, #f8f6f2 0%, #eee9e0 50%, #e8e0d4 100%)',
-      }}
-    >
-      <div className='relative w-full max-w-sm px-4'>
-        {/* 사이트 명 */}
-        <div className='mb-8 text-center'>
-          <span className='text-5xl font-black tracking-[0.4em] text-stone-800'>
-            GMART
-          </span>
-        </div>
-
-        {/* 카드 */}
-        <div className='rounded-3xl bg-white/90 p-8 shadow-xl shadow-stone-200/60 ring-1 ring-stone-100 backdrop-blur-sm'>
-          <h1 className='mb-7 text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
-            LOGIN
-          </h1>
-
-          <form onSubmit={handleSubmit} className='flex w-full flex-col gap-5'>
-            {/* 이메일 */}
-            <div className='flex flex-col gap-1'>
-              <input
-                type='email'
-                placeholder='이메일'
-                value={userEmail}
-                onChange={(e) => setUserEmail(e.target.value)}
-                required
-                className='w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100'
-              />
-            </div>
-
-            {/* 패스워드 */}
-            <div className='flex flex-col gap-1'>
-              <input
-                type='password'
-                placeholder='비밀번호'
-                value={userPassword}
-                onChange={(e) => setUserPassword(e.target.value)}
-                required
-                className='w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100'
-              />
-            </div>
-
-            {/* 에러 메시지 */}
-            {error && (
-              <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
-                <span className='text-red-400'>⚠</span>
-                <p className='text-sm text-red-600'>{error}</p>
-              </div>
-            )}
-
-            {/* 로그인 버튼 */}
-            <button
-              type='submit'
-              disabled={isLoading}
-              className='mt-1 w-full rounded-xl bg-stone-800 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-stone-700 disabled:opacity-50 hover:cursor-pointer'
-            >
-              {isLoading ? '로그인 중...' : '로그인'}
-            </button>
-          </form>
-
-          {/* 구분선 */}
-          <div className='my-6 flex items-center gap-3'>
-            <div className='h-px flex-1 bg-stone-300' />
-            <span className='text-xs tracking-widest text-stone-400'>OR</span>
-            <div className='h-px flex-1 bg-stone-300' />
+    <div className='min-h-screen bg-gray-50'>
+      <Header />
+      <div className='flex min-h-screen items-center justify-center bg-gray-50'>
+        <div className='relative w-full max-w-sm px-4'>
+          {/* 사이트 명 */}
+          <div className='mb-8 text-center'>
+            <span className='text-5xl font-black tracking-[0.4em] text-stone-800'>
+              GMART
+            </span>
           </div>
 
-          {/* 회원가입 링크 */}
-          <p className='text-center text-sm'>
-            <Link
-              to='/signup'
-              className='font-semibold text-stone-500 underline-offset-2 hover:underline'
+          {/* 카드 */}
+          <div className='rounded-3xl bg-white/90 p-8 shadow-xl shadow-stone-200/60 ring-1 ring-stone-100 backdrop-blur-sm'>
+            <h1 className='mb-7 text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
+              LOGIN
+            </h1>
+
+            <form
+              onSubmit={handleSubmit}
+              className='flex w-full flex-col gap-5'
             >
-              회원가입
-            </Link>
-          </p>
+              {/* 이메일 */}
+              <div className='flex flex-col gap-1'>
+                <input
+                  type='email'
+                  placeholder='이메일'
+                  value={userEmail}
+                  onChange={(e) => setUserEmail(e.target.value)}
+                  required
+                  className='w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100'
+                />
+              </div>
+
+              {/* 패스워드 */}
+              <div className='flex flex-col gap-1'>
+                <input
+                  type='password'
+                  placeholder='비밀번호'
+                  value={userPassword}
+                  onChange={(e) => setUserPassword(e.target.value)}
+                  required
+                  className='w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100'
+                />
+              </div>
+
+              {/* 에러 메시지 */}
+              {error && (
+                <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
+                  <span className='text-red-400'>⚠</span>
+                  <p className='text-sm text-red-600'>{error}</p>
+                </div>
+              )}
+
+              {/* 로그인 버튼 */}
+              <button
+                type='submit'
+                disabled={isLoading}
+                className='mt-1 w-full rounded-xl bg-stone-800 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-stone-700 disabled:opacity-50 hover:cursor-pointer'
+              >
+                {isLoading ? '로그인 중...' : '로그인'}
+              </button>
+            </form>
+
+            {/* 구분선 */}
+            <div className='my-6 flex items-center gap-3'>
+              <div className='h-px flex-1 bg-stone-300' />
+              <span className='text-xs tracking-widest text-stone-400'>OR</span>
+              <div className='h-px flex-1 bg-stone-300' />
+            </div>
+
+            {/* 회원가입 링크 */}
+            <p className='text-center text-sm'>
+              <Link
+                to='/signup'
+                className='font-semibold text-stone-500 underline-offset-2 hover:underline'
+              >
+                회원가입
+              </Link>
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/auth/SignupPage.test.tsx
+++ b/src/pages/auth/SignupPage.test.tsx
@@ -1,14 +1,31 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, renderMatches, useNavigate } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import SignupPage from './SignupPage';
 
 const mockNavigate = vi.fn();
+const mockSignup = vi.hoisted(() => vi.fn());
 
 vi.mock('react-router-dom', async () => {
   const act = await vi.importActual('react-router-dom');
   return { ...act, useNavigate: () => mockNavigate };
 });
+
+vi.mock('../../api/index', () => ({
+  authAPI: { signup: mockSignup },
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    isAdmin: false,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/Header', () => ({
+  default: () => null,
+}));
 
 const renderSignupPage = () =>
   render(
@@ -21,6 +38,7 @@ describe('SignupPage', () => {
   // 매 테스트 이전 초기화
   beforeEach(() => {
     mockNavigate.mockClear();
+    mockSignup.mockClear();
   });
 
   it('폼 렌더링', () => {
@@ -38,6 +56,7 @@ describe('SignupPage', () => {
   });
 
   it('회원가입 성공 시 /login 으로 이동', async () => {
+    mockSignup.mockResolvedValueOnce({});
     renderSignupPage();
 
     const user = userEvent.setup();

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -1,6 +1,13 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { authAPI } from '../../api/index';
+import Header from '../../components/Header';
 
+/**
+ * 회원가입 페이지
+ * - 이름, 이메일, 비밀번호, 비밀번호 확인 입력 폼
+ * - 회원가입 API 호출 후 로그인 페이지로 리다이렉트
+ */
 export default function SignupPage() {
   const navigate = useNavigate();
 
@@ -11,6 +18,11 @@ export default function SignupPage() {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
+  /**
+   * 폼 제출 핸들러
+   * - 입력값 검증
+   * - 회원가입 API 호출
+   */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -23,114 +35,132 @@ export default function SignupPage() {
     setIsLoading(true);
 
     try {
+      await authAPI.signup({
+        user_email: userEmail,
+        user_password: userPassword,
+        user_password_confirm: userPasswordConfirm,
+        user_name: userName,
+      });
       navigate('/login');
-    } catch {
-      setError('회원가입에 실패했습니다. 다시 시도해주세요.');
+    } catch (err: any) {
+      setError(
+        err.response?.data?.message ??
+          '회원가입에 실패했습니다. 다시 시도해주세요.',
+      );
     } finally {
       setIsLoading(false);
     }
   };
 
+  /**
+   * 입력 필드 공통 클래스
+   */
   const inputClass =
     'w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100';
 
+  /**
+   * 회원가입 폼
+   * - 이름, 이메일, 비밀번호, 비밀번호 확인 입력 필드
+   * - 에러 메시지 표시
+   * - 회원가입 버튼
+   */
   return (
-    <div
-      className='relative flex min-h-screen items-center justify-center overflow-hidden'
-      style={{
-        background:
-          'linear-gradient(135deg, #f8f6f2 0%, #eee9e0 50%, #e8e0d4 100%)',
-      }}
-    >
-      <div className='relative w-full max-w-sm px-4'>
-        {/* 사이트 명 */}
-        <div className='mb-8 text-center'>
-          <span className='text-5xl font-black tracking-[0.4em] text-stone-800'>
-            GMART
-          </span>
-        </div>
-
-        {/* 카드 */}
-        <div className='rounded-3xl bg-white/90 p-8 shadow-xl shadow-stone-200/60 ring-1 ring-stone-100 backdrop-blur-sm'>
-          <h1 className='mb-7 text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
-            SIGN UP
-          </h1>
-
-          <form onSubmit={handleSubmit} className='flex w-full flex-col gap-5'>
-            {/* 이름 */}
-            <input
-              type='text'
-              placeholder='이름'
-              value={userName}
-              onChange={(e) => setUserName(e.target.value)}
-              required
-              className={inputClass}
-            />
-
-            {/* 이메일 */}
-            <input
-              type='email'
-              placeholder='이메일'
-              value={userEmail}
-              onChange={(e) => setUserEmail(e.target.value)}
-              required
-              className={inputClass}
-            />
-
-            {/* 비밀번호 */}
-            <input
-              type='password'
-              placeholder='비밀번호'
-              value={userPassword}
-              onChange={(e) => setUserPassword(e.target.value)}
-              required
-              className={inputClass}
-            />
-
-            {/* 비밀번호 확인 */}
-            <input
-              type='password'
-              placeholder='비밀번호 확인'
-              value={userPasswordConfirm}
-              onChange={(e) => setUserPasswordConfirm(e.target.value)}
-              required
-              className={inputClass}
-            />
-
-            {/* 에러 메시지 */}
-            {error && (
-              <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
-                <span className='text-red-400'>⚠</span>
-                <p className='text-sm text-red-600'>{error}</p>
-              </div>
-            )}
-
-            {/* 회원가입 버튼 */}
-            <button
-              type='submit'
-              disabled={isLoading}
-              className='mt-1 w-full rounded-xl bg-stone-800 py-2.5 text-sm font-semibold text-white transition-colors hover:cursor-pointer hover:bg-stone-700 disabled:opacity-50'
-            >
-              {isLoading ? '처리 중...' : '회원가입'}
-            </button>
-          </form>
-
-          {/* 구분선 */}
-          <div className='my-6 flex items-center gap-3'>
-            <div className='h-px flex-1 bg-stone-300' />
-            <span className='text-xs tracking-widest text-stone-400'>OR</span>
-            <div className='h-px flex-1 bg-stone-300' />
+    <div className='min-h-screen bg-gray-50'>
+      <Header />
+      <div className='flex min-h-screen items-center justify-center bg-gray-50'>
+        <div className='relative w-full max-w-sm px-4'>
+          {/* 사이트 명 */}
+          <div className='mb-8 text-center'>
+            <span className='text-5xl font-black tracking-[0.4em] text-stone-800'>
+              GMART
+            </span>
           </div>
 
-          {/* 로그인 링크 */}
-          <p className='text-center text-sm'>
-            <Link
-              to='/login'
-              className='font-semibold text-stone-500 underline-offset-2 hover:underline'
+          {/* 카드 */}
+          <div className='rounded-3xl bg-white/90 p-8 shadow-xl shadow-stone-200/60 ring-1 ring-stone-100 backdrop-blur-sm'>
+            <h1 className='mb-7 text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
+              SIGN UP
+            </h1>
+
+            <form
+              onSubmit={handleSubmit}
+              className='flex w-full flex-col gap-5'
             >
-              로그인
-            </Link>
-          </p>
+              {/* 이름 */}
+              <input
+                type='text'
+                placeholder='이름'
+                value={userName}
+                onChange={(e) => setUserName(e.target.value)}
+                required
+                className={inputClass}
+              />
+
+              {/* 이메일 */}
+              <input
+                type='email'
+                placeholder='이메일'
+                value={userEmail}
+                onChange={(e) => setUserEmail(e.target.value)}
+                required
+                className={inputClass}
+              />
+
+              {/* 비밀번호 */}
+              <input
+                type='password'
+                placeholder='비밀번호'
+                value={userPassword}
+                onChange={(e) => setUserPassword(e.target.value)}
+                required
+                className={inputClass}
+              />
+
+              {/* 비밀번호 확인 */}
+              <input
+                type='password'
+                placeholder='비밀번호 확인'
+                value={userPasswordConfirm}
+                onChange={(e) => setUserPasswordConfirm(e.target.value)}
+                required
+                className={inputClass}
+              />
+
+              {/* 에러 메시지 */}
+              {error && (
+                <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
+                  <span className='text-red-400'>⚠</span>
+                  <p className='text-sm text-red-600'>{error}</p>
+                </div>
+              )}
+
+              {/* 회원가입 버튼 */}
+              <button
+                type='submit'
+                disabled={isLoading}
+                className='mt-1 w-full rounded-xl bg-stone-800 py-2.5 text-sm font-semibold text-white transition-colors hover:cursor-pointer hover:bg-stone-700 disabled:opacity-50'
+              >
+                {isLoading ? '처리 중...' : '회원가입'}
+              </button>
+            </form>
+
+            {/* 구분선 */}
+            <div className='my-6 flex items-center gap-3'>
+              <div className='h-px flex-1 bg-stone-300' />
+              <span className='text-xs tracking-widest text-stone-400'>OR</span>
+              <div className='h-px flex-1 bg-stone-300' />
+            </div>
+
+            {/* 로그인 링크 */}
+            <p className='text-center text-sm'>
+              <Link
+                to='/login'
+                className='font-semibold text-stone-500 underline-offset-2 hover:underline'
+              >
+                로그인
+              </Link>
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -1,3 +1,4 @@
+import { Card, TextInput, Button } from '@vapor-ui/core';
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { authAPI } from '../../api/index';
@@ -53,21 +54,15 @@ export default function SignupPage() {
   };
 
   /**
-   * 입력 필드 공통 클래스
-   */
-  const inputClass =
-    'w-full rounded-xl border border-stone-400 px-4 py-2.5 text-sm text-stone-800 outline-none placeholder:text-stone-400 focus:border-stone-600 focus:ring-2 focus:ring-stone-100';
-
-  /**
    * 회원가입 폼
    * - 이름, 이메일, 비밀번호, 비밀번호 확인 입력 필드
    * - 에러 메시지 표시
    * - 회원가입 버튼
    */
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='flex min-h-screen flex-col bg-gray-100'>
       <Header />
-      <div className='flex min-h-screen items-center justify-center bg-gray-50'>
+      <div className='flex flex-1 items-center justify-center'>
         <div className='relative w-full max-w-sm px-4'>
           {/* 사이트 명 */}
           <div className='mb-8 text-center'>
@@ -77,90 +72,86 @@ export default function SignupPage() {
           </div>
 
           {/* 카드 */}
-          <div className='rounded-3xl bg-white/90 p-8 shadow-xl shadow-stone-200/60 ring-1 ring-stone-100 backdrop-blur-sm'>
-            <h1 className='mb-7 text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
-              SIGN UP
-            </h1>
-
-            <form
-              onSubmit={handleSubmit}
-              className='flex w-full flex-col gap-5'
-            >
-              {/* 이름 */}
-              <input
-                type='text'
-                placeholder='이름'
-                value={userName}
-                onChange={(e) => setUserName(e.target.value)}
-                required
-                className={inputClass}
-              />
-
-              {/* 이메일 */}
-              <input
-                type='email'
-                placeholder='이메일'
-                value={userEmail}
-                onChange={(e) => setUserEmail(e.target.value)}
-                required
-                className={inputClass}
-              />
-
-              {/* 비밀번호 */}
-              <input
-                type='password'
-                placeholder='비밀번호'
-                value={userPassword}
-                onChange={(e) => setUserPassword(e.target.value)}
-                required
-                className={inputClass}
-              />
-
-              {/* 비밀번호 확인 */}
-              <input
-                type='password'
-                placeholder='비밀번호 확인'
-                value={userPasswordConfirm}
-                onChange={(e) => setUserPasswordConfirm(e.target.value)}
-                required
-                className={inputClass}
-              />
-
-              {/* 에러 메시지 */}
-              {error && (
-                <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
-                  <span className='text-red-400'>⚠</span>
-                  <p className='text-sm text-red-600'>{error}</p>
-                </div>
-              )}
-
-              {/* 회원가입 버튼 */}
-              <button
-                type='submit'
-                disabled={isLoading}
-                className='mt-1 w-full rounded-xl bg-stone-800 py-2.5 text-sm font-semibold text-white transition-colors hover:cursor-pointer hover:bg-stone-700 disabled:opacity-50'
+          <Card.Root>
+            <Card.Header>
+              <h1 className='text-center text-2xl font-bold tracking-[0.3em] text-stone-500'>
+                SIGN UP
+              </h1>
+            </Card.Header>
+            <Card.Body>
+              <form
+                onSubmit={handleSubmit}
+                className='flex w-full flex-col gap-5'
               >
-                {isLoading ? '처리 중...' : '회원가입'}
-              </button>
-            </form>
+                {/* 이름 */}
+                <TextInput
+                  type='text'
+                  placeholder='이름'
+                  value={userName}
+                  onChange={(e) => setUserName(e.target.value)}
+                  required
+                />
 
-            {/* 구분선 */}
-            <div className='my-6 flex items-center gap-3'>
-              <div className='h-px flex-1 bg-stone-300' />
-              <span className='text-xs tracking-widest text-stone-400'>OR</span>
-              <div className='h-px flex-1 bg-stone-300' />
-            </div>
+                {/* 이메일 */}
+                <TextInput
+                  type='email'
+                  placeholder='이메일'
+                  value={userEmail}
+                  onChange={(e) => setUserEmail(e.target.value)}
+                  required
+                />
 
-            {/* 로그인 링크 */}
-            <p className='text-center text-sm'>
-              <Link
-                to='/login'
-                className='font-semibold text-stone-500 underline-offset-2 hover:underline'
-              >
-                로그인
-              </Link>
-            </p>
-          </div>
+                {/* 비밀번호 */}
+                <TextInput
+                  type='password'
+                  placeholder='비밀번호'
+                  value={userPassword}
+                  onChange={(e) => setUserPassword(e.target.value)}
+                  required
+                />
+
+                {/* 비밀번호 확인 */}
+                <TextInput
+                  type='password'
+                  placeholder='비밀번호 확인'
+                  value={userPasswordConfirm}
+                  onChange={(e) => setUserPasswordConfirm(e.target.value)}
+                  required
+                  invalid={!!error}
+                />
+
+                {/* 에러 메시지 */}
+                {error && (
+                  <div className='flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3.5 py-2.5'>
+                    <span className='text-red-400'>⚠</span>
+                    <p className='text-sm text-red-600'>{error}</p>
+                  </div>
+                )}
+
+                {/* 회원가입 버튼 */}
+                <Button
+                  type='submit'
+                  disabled={isLoading}
+                  className='mt-1 w-full'
+                >
+                  {isLoading ? '처리 중...' : '회원가입'}
+                </Button>
+              </form>
+            </Card.Body>
+            <Card.Footer>
+              {/* 로그인 링크 */}
+              <div className='flex flex-col gap-4'>
+                <p className='text-center text-sm'>
+                  <Link
+                    to='/login'
+                    className='font-semibold text-stone-500 underline-offset-2 hover:underline'
+                  >
+                    로그인
+                  </Link>
+                </p>
+              </div>
+            </Card.Footer>
+          </Card.Root>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 주요 변경점

- AuthContext: Mock 데이터 제거, authAPI.login() / authAPI.logout() / userAPI.getMe() 실제 API 연동
- Header: 로그인 상태에 따른 조건부 UI 적용
- AdminRoute: 권한 없는 유저 접근 시 토스트 경고 메시지 표시
- LoginPage / SignupPage: vapor-ui 컴포넌트 적용, Header 추가 및 테스트 코드 오류 수정
- MemberManagePage / ProductManagePage : Header 추가 및 테스트 코드 오류 수정

## 관련 이슈

- Closes #9 

## 변경 유형

- [x] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 문서

## 테스트

- [x] 로컬 테스트 완료
- [x] 테스트 코드 작성/수정
